### PR TITLE
User import module fix

### DIFF
--- a/auth0.module
+++ b/auth0.module
@@ -1253,6 +1253,11 @@ function auth0_user_presave(&$edit, $account, $category) {
   }
   $connection = variable_get('auth0_user_push_connection', '');
 
+  watchdog('auth0', 'user_presave_called with variables @edit, @account', [
+   '@edit' => json_encode($edit),
+   '@account' => var_dump($account),
+  ], WATCHDOG_DEBUG);
+
   // skip if the user create came from Auth0, is not new or if push disabled.
 
   if (variable_get('auth0_user_push', FALSE) && isset($connection) && !isset($account->data['auth0_id'])) {

--- a/auth0.module
+++ b/auth0.module
@@ -1253,11 +1253,6 @@ function auth0_user_presave(&$edit, $account, $category) {
   }
   $connection = variable_get('auth0_user_push_connection', '');
 
-  watchdog('auth0', 'user_presave_called with variables @edit, @account', [
-   '@edit' => json_encode($edit),
-   '@account' => var_dump($account),
-  ], WATCHDOG_DEBUG);
-
   // skip if the user create came from Auth0, is not new or if push disabled.
 
   if (variable_get('auth0_user_push', FALSE) && isset($connection) && !isset($account->data['auth0_id'])) {
@@ -1284,12 +1279,25 @@ function auth0_user_presave(&$edit, $account, $category) {
 
         $mgmtClient = new Management($access_token, $domain);
 
+        $fields = ['mail', 'name'];
+        foreach ($fields as $field) {
+          if (isset($account->$field) && !empty($account->$field)) {
+            $$field = $account->$field;
+          }
+          elseif (!empty($edit[$field])) {
+            $$field = $edit[$field];
+          }
+          else {
+            $$field = NULL;
+          }
+        }
+
         $api_result = $mgmtClient->users->create(array(
           'connection' => $connection,
-          'email' => $account->mail,
+          'email' => $mail,
           'password' => user_password() . '!',  // Satisfy Auth0 password policy
           'email_verified' => TRUE,
-          'nickname' => $account->name,
+          'nickname' => $name,
           'app_metadata' => json_decode(variable_get('auth0_user_push_app_metadata', ''), true)
         ));
 

--- a/auth0.module
+++ b/auth0.module
@@ -1248,6 +1248,9 @@ function getDomain() {
  * Create the user in Auth0
  */
 function auth0_user_presave(&$edit, $account, $category) {
+  if (!auth0_check_dependencies()) {
+    return;
+  }
   $connection = variable_get('auth0_user_push_connection', '');
 
   // skip if the user create came from Auth0, is not new or if push disabled.

--- a/auth0.module
+++ b/auth0.module
@@ -1314,7 +1314,7 @@ function auth0_user_presave(&$edit, $account, $category) {
             'response_type' => 'code'
           );
 
-          $link_result = $auth0->email_passwordless_start($account->mail, 'link', $authParams);
+          $link_result = $auth0->email_passwordless_start($mail, 'link', $authParams);
 
           drupal_set_message(t('An Email with a one-time link has been sent.'), 'status');
         }


### PR DESCRIPTION
This makes specific changes to allow for the user module import can work with Auth0 module.

The 2 fundamental changes here that are needed is 

1) Loading in the composer dependancies such as the Auth0 PHP-SDK Library
2) Using the data contained in the $edit arrary if its not avaliable in the User object in the $account variable

There is also a corresponding change in Melons that is required but this has been tested in dev and appears to be working. There is still the issue of the fact that our dedupe rules means a new contact record is created when the import happens but that is a separate issue to this