### PR TITLE
Modify Auth0 configuration to persist ID Token in session storage

### DIFF
--- a/auth0.module
+++ b/auth0.module
@@ -212,7 +212,7 @@ function auth0_callback() {
       'client_secret' => $client_secret,
       'redirect_uri' => url('auth0/callback', array('absolute' => TRUE)),
       'store' => NULL, // Set to null so that the store is set to SessionStore.
-      'persist_id_token' => FALSE,
+      'persist_id_token' => TRUE,
       'persist_user' => FALSE,
       'persist_access_token' => FALSE,
       'persist_refresh_token' => FALSE    


### PR DESCRIPTION
This allows external apps to be integrated with Auth0 via Greenhouse, as you can make Greenhouse redirect to an external page passing the JWT, which can then be validated by the external app against the Auth0 public key.

For a working demonstration see https://statecouncil.enchanting.dev