### PR TITLE
Take into account user actions originating from drush

### DIFF
--- a/auth0.module
+++ b/auth0.module
@@ -190,8 +190,13 @@ function auth0_user_presave(\Drupal\Core\Entity\EntityInterface $account) {
   $connection = $config->get('auth0_user_push_connection');
 
   // skip if the user create came from Auth0, is not new or if push disabled.
+  // user actions from drush will not have a session, so this must also be considered
   $session = \Drupal::request()->getSession();
-  $sessionAuth0Id = $session->get('auth0_id') ?? 0;
+  if (!empty($session)) {
+    $sessionAuth0Id = $session->get('auth0_id') ?? 0;
+  else {
+    $sessionAuth0Id = 0;
+  }
   if ($config->get('auth0_user_push') && isset($connection) && empty($sessionAuth0Id)) {
     if ($account->isNew()) {
 


### PR DESCRIPTION
When attempting to run a drush command to add a role to a user, it fails with this message:

`[error]  Error: Call to a member function get() on null in auth0_user_presave() (line 194 of /var/www/html/web/modules/contrib/auth0/auth0.module) #0 [internal function]: auth0_user_presave()`

This is because the call to `\Drupal\request()->getSession()` returns `NULL` for drush calls.

However, it is sometimes legitimate to make these drush calls. These calls don't originate from auth0, and could possibly require a push to auth0 (in my case, it wouldn't have, but sometimes it might).

So I have put a test around the `$session` variable to ensure it's valid before attempting to see if it originated from auth0 or not.